### PR TITLE
feat(templater): improve template selection with project-aware context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,8 @@ dist/
 build/
 /bin/
 .commit_suggest_history.json
+.gitmit.json
+
 
 
 # Env


### PR DESCRIPTION
Enhance commit message templating by making it more context-aware and robust.

- Infer project scope from file paths for more relevant suggestions
- Add special handling for common files (e.g. README.md, LICENSE)
- Improve template scoring by penalizing missing data and rewarding scope matches
- Clean final output by removing empty parentheses and extra whitespace
- Ignore  via